### PR TITLE
Email Authorization Implemented (Changed from Username)

### DIFF
--- a/insert.sql
+++ b/insert.sql
@@ -1,0 +1,3 @@
+UPDATE auth_user
+SET username = 'me@me.com'
+WHERE id = 1;

--- a/rareapi/fixtures/users.json
+++ b/rareapi/fixtures/users.json
@@ -6,7 +6,7 @@
             "password": "pbkdf2_sha256$216000$qMRH8szID7Z8$Vljya2V3XfruOHuvx1hGz9ZyKg4bxbw7rc2WO0gTR7I=",
             "last_login": null,
             "is_superuser": false,
-            "username": "Carrie1945",
+            "username": "me@me.com",
             "first_name": "Carrie",
             "last_name": "Belk",
             "email": "me@me.com",

--- a/rareapi/views/auth.py
+++ b/rareapi/views/auth.py
@@ -18,7 +18,7 @@ def login_user(request):
 
     # Use the built-in authenticate method to verify
     # authenticate returns the user object or None if no user is found
-    authenticated_user = authenticate(email=email, password=password)
+    authenticated_user = authenticate(username=email, password=password)
 
     # If authentication was successful, respond with their token
     if authenticated_user is not None:
@@ -45,8 +45,7 @@ def register_user(request):
     # Create a new user by invoking the `create_user` helper method
     # on Django's built-in User model
     new_user = User.objects.create_user(
-        email=request.data['email'],
-        username=request.data['username'],
+        username=request.data['email'],
         password=request.data['password'],
         first_name=request.data['first_name'],
         last_name=request.data['last_name']

--- a/rareapi/views/auth.py
+++ b/rareapi/views/auth.py
@@ -13,12 +13,12 @@ def login_user(request):
     Method arguments:
       request -- The full HTTP request object
     '''
-    username = request.data['username']
+    email = request.data['email']
     password = request.data['password']
 
     # Use the built-in authenticate method to verify
     # authenticate returns the user object or None if no user is found
-    authenticated_user = authenticate(username=username, password=password)
+    authenticated_user = authenticate(email=email, password=password)
 
     # If authentication was successful, respond with their token
     if authenticated_user is not None:
@@ -45,6 +45,7 @@ def register_user(request):
     # Create a new user by invoking the `create_user` helper method
     # on Django's built-in User model
     new_user = User.objects.create_user(
+        email=request.data['email'],
         username=request.data['username'],
         password=request.data['password'],
         first_name=request.data['first_name'],


### PR DESCRIPTION
# Client Requested Email for login, changed nomenclature for server side code
## Steps to Test
- Fetch the` nc-email-auth` branch
- Run the following SQL command targeting your `db.sqlite3` if you have not already:
```
UPDATE auth_user
SET username = 'me@me.com'
WHERE id = 1;
```
- Start your debugger
- Using postman or the client, login with the following credentials - email: `me@me.com` password: `me`