### PR TITLE
Tags sorting alphabetically

### DIFF
--- a/rareapi/views/tags_view.py
+++ b/rareapi/views/tags_view.py
@@ -10,6 +10,6 @@ class TagSerializer(serializers.ModelSerializer):
 
 class TagView(viewsets.ViewSet):
     def list(self, request):
-        tags = Tags.objects.all()
+        tags = Tags.objects.all().order_by('label')
         serialized = TagSerializer(tags, many=True)
         return Response(serialized.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
# Tags now sorting alphabetically when returning a GET all request
## Steps to accomplish
- Added `.order_by('label')` to fetching all objects with ORM