### PR TITLE
changes to include author and category name

### DIFF
--- a/rareapi/views/post_view.py
+++ b/rareapi/views/post_view.py
@@ -6,11 +6,24 @@ from rareapi.models import Posts
 from django.contrib.auth.models import User
 
 
+class UserSerializer(serializers.ModelSerializer):
+    author_name = serializers.SerializerMethodField()
+
+    def get_author_name(self, obj):
+        return f"{obj.first_name} {obj.last_name}"
+    
+    class Meta:
+        model = User
+        fields = ('author_name',)
+
+
 class PostSerializer(serializers.ModelSerializer):
+    author = UserSerializer(source='user', read_only=True)
+    category_name = serializers.CharField(source='category.label', read_only=True)
 
     class Meta:
         model = Posts
-        fields = ('id', 'user', 'category', 'title', 'publication_date', 'image_url', 'content', 'approved', 'tags', )
+        fields = ('id', 'author', 'category_name', 'title', 'publication_date', 'image_url', 'content', 'approved', 'tags', )
 
 
 class PostView(ViewSet):


### PR DESCRIPTION
# Adjustments to PostView and serializers
Added serializers to PostView
Changes add fields such as author's name and category name so they will list on the Client

Expected response
When you make the get request to http://localhost:8000/posts (with your token), you should see:
```[
    {
        "id": 1,
        "author": {
            "author_name": "Carrie Belk"
        },
        "category_name": "Funny",
        "title": "Sample Post Number One",
        "publication_date": "2023-11-11",
        "image_url": "http://example.com/firstimage.jpg",
        "content": "This is the content of the first post.",
        "approved": true,
        "tags": [
            1,
            3,
            5
        ]
    }
]

