### PR TITLE
added retrieve method to post_view.py

### DIFF
--- a/rareapi/views/post_view.py
+++ b/rareapi/views/post_view.py
@@ -48,3 +48,7 @@ class PostView(ViewSet):
         serialized = PostSerializer(posts, many=True)
         return Response(serialized.data, status=status.HTTP_200_OK)
 
+    def retrieve(self, request, pk=None):
+        single_post = Posts.objects.get(pk=pk)
+        post_serialized = PostSerializer(single_post)
+        return Response(post_serialized.data)


### PR DESCRIPTION
# Added retrieve method to post_view.py
## Had to add a retrieve method in preparation for listing Post Details when posts are clicked

When you make the get request to http://localhost:8000/posts/2 with your token, you should see:

```{
    "id": 2,
    "author": {
        "author_name": "Carrie Belk"
    },
    "category_name": "Lifestyle",
    "title": "Sample Post Number Two",
    "publication_date": "2023-11-12",
    "image_url": "http://example.com/secondimage.jpg",
    "content": "This is the content of the second post.",
    "approved": false,
    "tags": [
        2,
        4,
        6
    ],
    "comments": [
        {
            "id": 2,
            "content": "Insightful",
            "created_on": "2023-11-17",
            "author": {
                "id": 1,
                "user": {
                    "author_name": "Carrie Belk"
                }
            }
        }
    ]
}